### PR TITLE
allow pagePath to be set on a per-request basis in addition to globally

### DIFF
--- a/lib/renderer/renderer-webpack.js
+++ b/lib/renderer/renderer-webpack.js
@@ -221,9 +221,10 @@ class Renderer {
         }
 
         const useRoot = filePath.indexOf(this.expressVueFolder) > -1
+        const pageContext = page.context && !useRoot ? page.context : ''
         const filePathRoot = useRoot ? this.rootPath : page.path;
-        const parsedFilePath = filePath.replace(filePathRoot, "").replace(".vue", "");
-        const configFolder = path.join(this.expressVueFolder, parsedFilePath);
+        const parsedFilePath = filePath.replace(filePathRoot, "").replace(".vue", "").replace('.expressvue', '');
+        const configFolder = path.join(this.expressVueFolder, pageContext, parsedFilePath);
 
         const serverFilename = "server.bundle.js";
         const clientFilename = "client.bundle.js";
@@ -245,7 +246,7 @@ class Renderer {
             }
         }
 
-        const memoryBase = path.resolve(path.join(`/${this.baseUrl}`, '/expressvue/bundles', page.context ? page.context : '', memoryParsed.dir)); // add C: for memory file system for windows machines
+        const memoryBase = path.resolve(path.join(`/${this.baseUrl}`, '/expressvue/bundles', pageContext, memoryParsed.dir)); // add C: for memory file system for windows machines
         const memoryPath = path.join(memoryBase, memoryParsed.name);
 
         return {
@@ -434,7 +435,7 @@ class Renderer {
      * @returns {Promise<String>}
      */
     async _findFile(vueFile, parentRoute = "", pagePath = this.pagesPath) {
-        const cacheKey = vueFile + parentRoute;
+        const cacheKey = pagePath + vueFile + parentRoute;
         const cached = this.lruCache.get(cacheKey);
 
         let pathToTest = "";

--- a/lib/renderer/renderer-webpack.js
+++ b/lib/renderer/renderer-webpack.js
@@ -35,6 +35,9 @@ const MFS = require("memory-fs");
 /**
  * @typedef VueOptionsType
  * @prop {String} title
+ * @prop {Object} page
+ * @prop {string} page.path
+ * @prop {string} page.context
  * @prop {Object} head
  * @prop {Object[]} head.scripts
  * @prop {Object[]} head.metas
@@ -195,11 +198,11 @@ class Renderer {
      * @param {object[]} filepaths
      * @returns {Promise<void>}
      */
-    async _loadBundleFilesToMemory(filepaths) {
+    async _loadBundleFilesToMemory(filepaths, page) {
         const vm = this;
         for (var i = 0, len = filepaths.length; i < len; i++) {
             const filepath = filepaths[i];
-            const bundlePath = this.getBundleFilePath(filepath);
+            const bundlePath = this.getBundleFilePath(filepath, page);
             vm.mfs.mkdirpSync(bundlePath.memory.base);
             const file = await promiseFS.readFile(filepath);
             vm.mfs.writeFileSync(`${bundlePath.memory.path}.js`, file);
@@ -208,22 +211,36 @@ class Renderer {
     }
     /**
      * @param {string} filePath
+     * @param {Object} page
      * @returns {BundleFileType}
      */
-    getBundleFilePath(filePath) {
-        const parsedFilePath = filePath.replace(this.rootPath, "").replace(".vue", "");
-        const expressVueFolder = path.join(this.rootPath, ".expressvue");
-        const configFolder = path.join(expressVueFolder, parsedFilePath);
+    getBundleFilePath(filePath, page) {
+        const useRoot = filePath.indexOf(this.expressVueFolder) > -1
+        const filePathRoot = useRoot ? this.expressVueFolder : page.path;
+        const parsedFilePath = filePath.replace(filePathRoot, "").replace(".vue", "");
+        const configFolder = path.join(this.expressVueFolder, parsedFilePath);
+
         const serverFilename = "server.bundle.js";
         const clientFilename = "client.bundle.js";
         let memoryParsed;
+
         if (filePath.includes(".expressvue")) {
-            memoryParsed = path.parse(filePath.replace(".expressvue" + path.sep, "").split(this.pagesPath)[1]);
+            let memoryPath = filePath.replace(".expressvue" + path.sep, "").split(filePathRoot)
+            if (memoryPath.length > 1) {
+                memoryParsed = path.parse(memoryPath[1]);
+            } else {
+                throw new Error('Failed to determine memory path in root');
+            }
         } else {
-            memoryParsed = path.parse(filePath.split(this.pagesPath)[1]);
+            let memoryPath = filePath.split(filePathRoot)
+            if (memoryPath.length > 1) {
+                memoryParsed = path.parse(memoryPath[1]);
+            } else {
+                throw new Error('Failed to determine memory path');
+            }
         }
 
-        const memoryBase = path.resolve(path.join(`/${this.baseUrl}`, '/expressvue/bundles', memoryParsed.dir)); // add C: for memory file system for windows machines
+        const memoryBase = path.resolve(path.join(`/${this.baseUrl}`, '/expressvue/bundles', page.context ? page.context : '', memoryParsed.dir)); // add C: for memory file system for windows machines
         const memoryPath = path.join(memoryBase, memoryParsed.name);
 
         return {
@@ -248,11 +265,12 @@ class Renderer {
     }
     /**
      * @param {string} filePath
+     * @param {Object} page
      * @returns {Promise<WebpackConfigType>}
      */
-    async _buildConfig(filePath) {
-        const bundlePath = this.getBundleFilePath(filePath);
-        const {app, server, client} = config.appConfig(filePath, this.vue);
+    async _buildConfig(filePath, page) {
+        const bundlePath = this.getBundleFilePath(filePath, page);
+        const { app, server, client } = config.appConfig(filePath, this.vue);
 
         try {
             await promiseFS.statIsDirectory(bundlePath.base);
@@ -298,15 +316,16 @@ class Renderer {
     /**
      *
      * @param {WebpackConfigType} webpackConfig
+     * @param {Object} page
      * @param {string} filePath
      * @returns {Promise<{client: string, server: string, clientBundlePath: string}>}
      */
-    async _makeBundle(webpackConfig, filePath) {
-        const bundlePath = this.getBundleFilePath(filePath);
+    async _makeBundle(webpackConfig, filePath, page) {
+        const bundlePath = this.getBundleFilePath(filePath, page);
         //file was not found so make it
         await this._webPackCompile(webpackConfig.config, filePath);
         const bundleFilePaths = find.fileSync(/bundle\.js$/, this.expressVueFolder);
-        await this._loadBundleFilesToMemory(bundleFilePaths);
+        await this._loadBundleFilesToMemory(bundleFilePaths, page);
         let serverBundle = this.mfs.readFileSync(bundlePath.memory.filename.server, "utf-8");
         let clientBundle = this.mfs.readFileSync(bundlePath.memory.filename.client, "utf-8");
         if (!serverBundle || !clientBundle) {
@@ -353,12 +372,13 @@ class Renderer {
      *
      * @param {string} filePath
      * @param {object} context
+     * @param {Object} page
      * @returns {Promise<{renderer: {renderToStream: Function, renderToString: Function}, client: string, clientBundlePath: string}>}
      */
-    async _makeVueClass(filePath, context) {
+    async _makeVueClass(filePath, context, page) {
         //Check if the bundle exists if not make a new one
         try {
-            const bundlePath = this.getBundleFilePath(filePath);
+            const bundlePath = this.getBundleFilePath(filePath, page);
             context.script = path.join('/', path.relative(path.resolve('/'), bundlePath.memory.filename.client)); // strip drive letter for windows systems
             const layout = buildLayoutWebpack(context);
 
@@ -380,8 +400,8 @@ class Renderer {
             };
         } catch (error) {
             //Make Bundle
-            const webpackConfig = await this._buildConfig(filePath);
-            const bundle = await this._makeBundle(webpackConfig, filePath);
+            const webpackConfig = await this._buildConfig(filePath, page);
+            const bundle = await this._makeBundle(webpackConfig, filePath, page);
             context.script = path.join('/', path.relative(path.resolve('/'), bundle.clientBundlePath)); // strip drive letter for windows systems
             const layout = buildLayoutWebpack(context);
 
@@ -405,20 +425,23 @@ class Renderer {
      *
      * @param {String} vueFile
      * @param {String} [parentRoute=""]
+     * @param {String} pagePath
      * @returns {Promise<String>}
      */
-    async _findFile(vueFile, parentRoute = "") {
+    async _findFile(vueFile, parentRoute = "", pagePath = this.pagesPath) {
         const cacheKey = vueFile + parentRoute;
         const cached = this.lruCache.get(cacheKey);
+
         let pathToTest = "";
         if (cached) {
             return cached;
         } else {
-            if (this.pagesPath === undefined) {
+            if (pagePath === undefined) {
                 pathToTest = vueFile;
             } else {
-                pathToTest = path.join(this.pagesPath, vueFile);
+                pathToTest = path.join(pagePath, vueFile);
             }
+
             await promiseFS.access(pathToTest);
             this.lruCache.set(cacheKey, pathToTest);
         }
@@ -432,7 +455,9 @@ class Renderer {
      * @returns {Promise<string>}
      */
     async RenderToString(vueFile, data, vueOptions) {
-        const filePath = await this._findFile(vueFile);
+        let pagePath = vueOptions.page ? vueOptions.page.path || this.pagesPath : this.pagesPath
+
+        const filePath = await this._findFile(vueFile, '', pagePath);
         const mergedHeadObject = mergeHead(
             vueOptions.head,
             this.head,
@@ -447,7 +472,14 @@ class Renderer {
             head: buildHead(mergedHeadObject, mergedData),
             template: template,
         };
-        const vueClass = await this._makeVueClass(filePath, context);
+
+
+        const pageOptions = Object.assign({
+            path: this.pagesPath,
+            context: null
+        }, vueOptions.page || {})
+
+        const vueClass = await this._makeVueClass(filePath, context, pageOptions);
         return await vueClass.renderer.renderToString(mergedData);
     }
     /**
@@ -458,7 +490,8 @@ class Renderer {
      * @return {Promise<NodeJS.ReadableStream>}
      */
     async RenderToStream(vueFile, data, vueOptions) {
-        const filePath = await this._findFile(vueFile);
+        let pagePath = vueOptions.page ? vueOptions.page.path || this.pagesPath : this.pagesPath
+        const filePath = await this._findFile(vueFile, '', pagePath);
         const mergedHeadObject = mergeHead(
             vueOptions.head,
             this.head,
@@ -477,7 +510,13 @@ class Renderer {
             head: headString,
             template: template,
         };
-        const vueClass = await this._makeVueClass(filePath, context);
+
+        const pageOptions = Object.assign({
+            path: this.pagesPath,
+            context: null
+        }, vueOptions.page || {})
+
+        const vueClass = await this._makeVueClass(filePath, context, pageOptions);
         const vueStream = vueClass.renderer.renderToStream(mergedData);
         const htmlStream = new StreamUtils();
         return vueStream.pipe(htmlStream);

--- a/lib/renderer/renderer-webpack.js
+++ b/lib/renderer/renderer-webpack.js
@@ -196,6 +196,7 @@ class Renderer {
     }
     /**
      * @param {object[]} filepaths
+     * @param {Object} page
      * @returns {Promise<void>}
      */
     async _loadBundleFilesToMemory(filepaths, page) {
@@ -215,8 +216,12 @@ class Renderer {
      * @returns {BundleFileType}
      */
     getBundleFilePath(filePath, page) {
+        if (!page) {
+            page = { path: this.pagesPath, context: null }
+        }
+
         const useRoot = filePath.indexOf(this.expressVueFolder) > -1
-        const filePathRoot = useRoot ? this.expressVueFolder : page.path;
+        const filePathRoot = useRoot ? this.rootPath : page.path;
         const parsedFilePath = filePath.replace(filePathRoot, "").replace(".vue", "");
         const configFolder = path.join(this.expressVueFolder, parsedFilePath);
 

--- a/tests/example/otherviews/error.vue
+++ b/tests/example/otherviews/error.vue
@@ -1,0 +1,28 @@
+<template>
+  <div>
+    <h1 class="blue">{{msg}}</h1>
+    <foo hellodata="component"></foo>
+  </div>
+</template>
+ 
+<script>
+import foo from "../components/copy/component.vue";
+export default {
+    data: function () {
+        return {
+            msg: 'Hello world!',
+            messageOuter: 'Say Foo'
+        }
+    },
+    components: {
+        foo
+    }
+}
+</script>
+ 
+<style>
+  .blue {
+    color: #00f;
+  }
+</style> 
+ 

--- a/tests/example/otherviews/index/index-webpack.vue
+++ b/tests/example/otherviews/index/index-webpack.vue
@@ -1,0 +1,61 @@
+<template>
+  <div>
+    <h1 class="blue">{{msg}}</h1>
+    <foo hellodata="component"></foo>
+    <p>{{bar}}</p>
+    <div v-html="fakehtml"></div>
+    <h1>{{title}}</h1>
+    <p>Welcome to the {{title}} demo. Click a link:</p>
+    <p>{{sentence}}</p>
+    <input v-model="messageOuter" placeholder="edit me">
+    <button type="button" name="button" v-on:click="hello(messageOuter)">{{messageOuter}}</button>
+    <message-comp :message="messageOuter"></message-comp>
+    <users :users="users"></users>
+    <simple></simple>
+  </div>
+</template>
+
+<script>
+import axios from "axios";
+import foo from "../../components/component.vue";
+import messageComp from '../../components/message-comp.vue';
+import users from '../../components/users.vue';
+import helloMixin from '../../mixins/exampleMixin.js';
+import simple from 'simple-vue-component-test/simple.vue';
+export default {
+    props: {
+        title: {
+            type: String,
+            default: ""
+        },
+        users: {
+            type: Array,
+            default: function() {
+                return [{name: "default"}];
+            }
+        }
+    },
+    data: function () {
+        return {
+            bar: false,
+            sentence: '',
+            fakehtml: '',
+            msg: 'Hello world!',
+            messageOuter: 'Say Foo'
+        }
+    },
+    components: {
+        foo,
+        messageComp,
+        users,
+        simple
+    },
+    mixins: [helloMixin]
+}
+</script>
+
+<style>
+  .blue {
+    color: #00f;
+  }
+</style>

--- a/tests/example/otherviews/index/index.vue
+++ b/tests/example/otherviews/index/index.vue
@@ -1,0 +1,58 @@
+<template>
+  <div>
+    <h1 class="blue">{{msg}}</h1>
+    <foo hellodata="component"></foo>
+    <p>{{bar}}</p>
+    <div v-html="fakehtml"></div>
+    <h1>{{title}}</h1>
+    <p>Welcome to the {{title}} demo. Click a link:</p>
+    <p>{{sentence}}</p>
+    <input v-model="messageOuter" placeholder="edit me">
+    <button type="button" name="button" v-on:click="hello(messageOuter)">{{messageOuter}}</button>
+    <message-comp :message="messageOuter"></message-comp>
+    <users :users="users"></users>
+    <simple></simple>
+  </div>
+</template>
+ 
+<script>
+import axios from "axios";
+import foo from "../../components/component.vue";
+import messageComp from '../../components/message-comp.vue';
+import users from '../../components/users.vue';
+import helloMixin from '../../mixins/exampleMixin.js';
+import simple from 'simple-vue-component-test/simple.vue';
+export default {
+    props: {
+        title: {
+            type: String,
+            default: ""
+        },
+        users: {
+            type: Array,
+            default: function() {
+                return [{name: "default"}];
+            }
+        }
+    },
+    data: function () {
+        return {
+            msg: 'Hello world!',
+            messageOuter: 'Say Foo'
+        }
+    },
+    components: {
+        foo,
+        messageComp,
+        users,
+        simple
+    },
+    mixins: [helloMixin]
+}
+</script>
+ 
+<style>
+  .blue {
+    color: #00f;
+  }
+</style> 

--- a/tests/expected/string-zero-config-other.html
+++ b/tests/expected/string-zero-config-other.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html><html><head><script>window.__INITIAL_STATE__ = {"bar":true,"fakehtml":"\u003Cp class=\"red\"\u003EFAKEHTML\u003C\u002Fp\u003E"}</script><style data-vue-ssr-id="14ef4d8a:0">
+.blue {
+  color: #00f;
+}
+</style><style data-vue-ssr-id="57b7dbba:0">
+.subcomponent[data-v-2fafd565] {
+    color: green;
+}
+h2[data-v-2fafd565] {
+  font-size: 40px;
+}
+</style><style data-vue-ssr-id="12762f70:0">
+.test {
+    color: pink;
+    font-size: 20px;
+}
+</style><style data-vue-ssr-id="623ed4a1:0">
+.simple {
+    color: blue;
+    text-decoration: underline;
+}
+</style><style data-vue-ssr-id="14ef4d8a:0">
+.blue {
+  color: #00f;
+}
+</style><style data-vue-ssr-id="57b7dbba:0">
+.subcomponent[data-v-2fafd565] {
+    color: green;
+}
+h2[data-v-2fafd565] {
+  font-size: 40px;
+}
+</style><style data-vue-ssr-id="12762f70:0">
+.test {
+    color: pink;
+    font-size: 20px;
+}
+</style><style data-vue-ssr-id="623ed4a1:0">
+.simple {
+    color: blue;
+    text-decoration: underline;
+}
+</style></head><body><div id="app"><div data-server-rendered="true"><h1 class="blue">Hello world!</h1> <div><h2>Hello from component</h2> <button type="button" name="button">component</button> <h2 class="subcomponent" data-v-2fafd565>Hello from subcomponent</h2></div> <p>true</p> <div><p class="red">FAKEHTML</p></div> <h1></h1> <p>Welcome to the  demo. Click a link:</p> <p></p> <input placeholder="edit me" value="Say Foo"> <button type="button" name="button">Say Foo</button> <div><h1>Say Foo</h1></div> <div><ul><li><a href="/users/default" class="test">default</a></li></ul></div> <div><p class="simple">Hello From Component in node_modules</p></div></div></div><script src="/expressvue/bundles/otherviews/index/index-webpack/client.bundle.js"></script></body></html>

--- a/tests/renderer-webpack.js
+++ b/tests/renderer-webpack.js
@@ -27,6 +27,31 @@ test("String returns with zero config", async t => {
 });
 
 //@ts-ignore
+test("String returns with zero config from defined folder, into a defined context folder", async t => {
+    // @ts-ignore
+    const renderer = new Pronto({pagesPath: pagesPath});
+    const data = {
+        bar: true,
+        fakehtml: '<p class="red">FAKEHTML</p>',
+    };
+    const templateLiteral = `<!DOCTYPE html>\n<html lang="en">\n<head>\n<title>{{title}}</title>\n<style>{{css}}</style>\n</head>\n<body>\n<h1>FOOOOO</h1>\n<!--vue-ssr-outlet-->\n</body>\n</html>`;
+
+    const vueOptions = {
+        title: "Test",
+        template: templateLiteral,
+        page: {
+            path: path.normalize(path.join(__dirname, "../tests/example/otherviews")),
+            context: 'otherviews'
+        }
+    };
+    const expectedFile = path.join(expectedPath, "string-zero-config-other.html");
+    const expected = fs.readFileSync(expectedFile).toString();
+    const rendered = await renderer.RenderToString("index/index-webpack.vue", data, vueOptions);
+    t.is(rendered, expected);
+    t.true(fs.existsSync(path.join(__dirname, '../.expressvue/otherviews/index')))
+});
+
+//@ts-ignore
 test("String returns with some config", async t => {
     // @ts-ignore
     const renderer = new Pronto({


### PR DESCRIPTION
Code that is separated out into modules require the use of multiple `pagePaths`. I've added a way to define the `pagePath` on a per-request basis by providing a `page` key/value to the `vueOptions` in `renderVue`.

In addition to that, I've added a context field that can give a sort of namespace to the compiled folder allowing for multiple files to be rendered when they share the same name. (e.g. users/index and groups/index)

The new `pages` field is optional, as well as either the `path` or `context` fields in it. If nothing is provided, the program will behave as it does currently making this a non-breaking change. If `path` is not provided it will default to the global `pagesPath`. If `context` is not provided it will write everything to the root of `.expressvue`

Also I've added some minor error-checking for when the `memoryParsed` variable is trying to be determined.

Here would be an example of using `renderVue` with the changes:

```js

const vueOptions = {
    pagesPath: './src/views/pages'
}

expressVue.use(app, vueOptions).then((app) => {
    app.get('/', (req, res) => {
        // this looks at ./src/views/pages, using the vueOptions.pagesPath by default
        // and compiles to rootPath/.expressvue/Index
        res.renderVue('Index.vue', {}, {})
    })

    app.get('/users', (req, res) => {
        // this looks at ./src/users/views/pages/Index.vue
        // and compiles to rootPath/.expressvue/User/Index
        res.renderVue('Index.vue', {}, {
            page: {
                path: './src/users/views/pages',
                context: 'Users'
            }
        })
    })

    app.get('/groups', (req, res) => {
        // this looks at ./src/groups/views/pages/Index.vue
        // and compiles to rootPath/.expressvue/Groups/Index
        res.renderVue('Index.vue', {}, {
            page: {
                path: './src/groups/views/pages',
                context: 'Groups'
            }
        })
    })

    app.get('/permissions', (req, res) => {
        // this looks at ./src/permissions/views/pages/Add.vue
        // and compiles to rootPath/.expressvue/Add
        res.renderVue('Add.vue', {}, {
            page: {
                path: './src/permissions/views/pages',
            }
        })
    })
})
```